### PR TITLE
fix: 修复 UDP 缓冲区数据延迟问题

### DIFF
--- a/contrlSDK/Robot.cpp
+++ b/contrlSDK/Robot.cpp
@@ -493,7 +493,7 @@ bool CRobot::OnClearChDataA()
 	{
 		num = m_InsRobot->m_ACB1.ReadBuf((unsigned char*)&t, si);
 	}
-	if(m_InsRobot->m_LocalLogTag == true) printf("[Marvin SDK]: Clear 485 cache of A arm\n");
+	// if(m_InsRobot->m_LocalLogTag == true) printf("[Marvin SDK]: Clear 485 cache of A arm\n");
 
 	return true;
 }
@@ -512,7 +512,7 @@ bool CRobot::OnClearChDataB()
 	{
 		num = m_InsRobot->m_ACB2.ReadBuf((unsigned char*)&t, si);
 	}
-    if(m_InsRobot->m_LocalLogTag == true) printf("[Marvin SDK]: Clear 485 cache of B arm\n");
+    // if(m_InsRobot->m_LocalLogTag == true) printf("[Marvin SDK]: Clear 485 cache of B arm\n");
 	return true;
 }
 
@@ -1451,83 +1451,139 @@ void CRobot::DoRecv()
 		return;
 	}
 
-	_localLen = sizeof(_local);
+	// 临时存储最新的 DCSS 数据
+	// 使用 static 避免每次调用都在栈上分配 ~2KB 内存
+	static DCSS temp_dcss;
+	bool got_dcss_data = false;
+	int dcss_packet_count = 0;
+
+	// 循环读取所有堆积的 UDP 数据包，直到缓冲区为空
+	// 目的：清空旧数据，只使用最新的数据包
+	while (true)
+	{
+		_localLen = sizeof(_local);
 
 #ifdef CMPL_WIN
-	int Len = recvfrom(_local_sock, recvbuf, 2000, 0, (struct sockaddr*)&_local, &_localLen);
+		int Len = recvfrom(_local_sock, recvbuf, 2000, 0, (struct sockaddr*)&_local, &_localLen);
 #endif
 #ifdef CMPL_LIN
-	int Len = recvfrom(_local_sock, recvbuf, 2000, 0, (struct sockaddr*)&_local, (socklen_t*)&_localLen);
+		int Len = recvfrom(_local_sock, recvbuf, 2000, 0, (struct sockaddr*)&_local, (socklen_t*)&_localLen);
 #endif
-	
-	if (Len == sizeof(DCSS) + 2)
-	{
-		if (recvbuf[0] == 'F' && recvbuf[1] == 'X')
-		{
-			DCSS* p = (DCSS*)&recvbuf[2];
-			memcpy(&m_DCSS, p, sizeof(m_DCSS));
-			if (m_InsRobot->m_GatherTag == 1)
-			{
-				if (m_GatherRecordNum >= m_GatherRecordMaxNum)
-				{
-					m_GatherTag = 4;
-				}
-				else
-				{
-					double v[40];
-					for (long i = 0; i < m_GatherItemSize; i++)
-					{
-						v[i+2] = *m_GatherItem[i];
-					}
-					v[0] = m_DCSS.m_Out[0].m_OutFrameSerial;
-					//if(m_InsRobot->m_LocalLogTag == true) printf("%lf\n",v[0]);
-					v[1] = m_DCSS.m_Out[1].m_OutFrameSerial;
-					m_GatherSet.OnSetPoint(v);
-					m_GatherRecordNum++;
-				}
-			}
-			
-			if (m_InsRobot->m_GatherTag == 2)
-			{
-				m_InsRobot->m_GatherTag = 4;
-			}
 
-			if (old_serial_tag == FX_FALSE)
+		// 非阻塞 socket：Len < 0 表示缓冲区为空或发生错误
+		if (Len < 0)
+		{
+#ifdef CMPL_LIN
+			// Linux: EAGAIN 或 EWOULDBLOCK 表示缓冲区为空（正常情况）
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
 			{
-				old_serial_tag = true;
+				break;  // 缓冲区已空，退出循环
+			}
+#endif
+#ifdef CMPL_WIN
+			// Windows: WSAEWOULDBLOCK 表示缓冲区为空
+			int err = WSAGetLastError();
+			if (err == WSAEWOULDBLOCK)
+			{
+				break;  // 缓冲区已空，退出循环
+			}
+#endif
+			// 其他错误，退出循环
+			break;
+		}
+
+		// 处理机器人状态数据包（DCSS）
+		if (Len == sizeof(DCSS) + 2)
+		{
+			if (recvbuf[0] == 'F' && recvbuf[1] == 'X')
+			{
+				DCSS* p = (DCSS*)&recvbuf[2];
+				memcpy(&temp_dcss, p, sizeof(temp_dcss));
+				got_dcss_data = true;
+				dcss_packet_count++;
+			}
+		}
+		// 处理通信数据包（DDSS）- 每个包都需要处理
+		else if(Len == sizeof(DDSS) + 2)
+		{
+			if (recvbuf[0] == 'C' && recvbuf[1] == 'H')
+			{
+				DDSS* p = (DDSS*)&recvbuf[2];
+				if (p->m_CH == 1)
+				{
+					m_ACB1.WriteBuf((unsigned char *)p, sizeof(DDSS));
+				}
+
+				if (p->m_CH == 2)
+				{
+					m_ACB2.WriteBuf((unsigned char*)p, sizeof(DDSS));
+				}
+			}
+		}
+
+		// 安全限制：防止无限循环，最多读取 100 个 DCSS 包
+		// 如果缓冲区堆积超过 100 个包（0.1秒），说明系统严重过载
+		if (dcss_packet_count >= 100)
+		{
+			if (m_InsRobot->m_LocalLogTag == true)
+			{
+				printf("[Marvin SDK Warning]: UDP buffer overflow, cleared %d packets\n", dcss_packet_count);
+			}
+			break;
+		}
+	}
+
+	// 只在读取到新数据时更新 m_DCSS（使用最后一次读取的最新数据）
+	if (got_dcss_data)
+	{
+		memcpy(&m_DCSS, &temp_dcss, sizeof(m_DCSS));
+
+		// 数据采集处理
+		if (m_InsRobot->m_GatherTag == 1)
+		{
+			if (m_GatherRecordNum >= m_GatherRecordMaxNum)
+			{
+				m_GatherTag = 4;
+			}
+			else
+			{
+				double v[40];
+				for (long i = 0; i < m_GatherItemSize; i++)
+				{
+					v[i+2] = *m_GatherItem[i];
+				}
+				v[0] = m_DCSS.m_Out[0].m_OutFrameSerial;
+				//if(m_InsRobot->m_LocalLogTag == true) printf("%lf\n",v[0]);
+				v[1] = m_DCSS.m_Out[1].m_OutFrameSerial;
+				m_GatherSet.OnSetPoint(v);
+				m_GatherRecordNum++;
+			}
+		}
+
+		if (m_InsRobot->m_GatherTag == 2)
+		{
+			m_InsRobot->m_GatherTag = 4;
+		}
+
+		// 帧序号检测与丢帧统计
+		if (old_serial_tag == FX_FALSE)
+		{
+			old_serial_tag = true;
+			old_serial = m_DCSS.m_Out[0].m_OutFrameSerial;
+		}
+		else
+		{
+			old_serial += 1;
+			old_serial %= 1000000;
+			if (old_serial != m_DCSS.m_Out[0].m_OutFrameSerial)
+			{
+				miss_cnt++;
 				old_serial = m_DCSS.m_Out[0].m_OutFrameSerial;
 			}
 			else
 			{
-				old_serial += 1;
-				old_serial %= 1000000;
-				if (old_serial != m_DCSS.m_Out[0].m_OutFrameSerial)
-				{
-					miss_cnt++;
-					old_serial = m_DCSS.m_Out[0].m_OutFrameSerial;
-				}
-				else
-				{
-					miss_cnt = 0;
-				}
+				miss_cnt = 0;
 			}
-		}
-	}
-	else if(Len == sizeof(DDSS) + 2)
-	{
-		if (recvbuf[0] == 'C' && recvbuf[1] == 'H')
-		{
-			DDSS* p = (DDSS*)&recvbuf[2];
-			if (p->m_CH == 1)
-			{
-				m_ACB1.WriteBuf((unsigned char *)p, sizeof(DDSS));
-			}
-
-			if (p->m_CH == 2)
-			{
-				m_ACB2.WriteBuf((unsigned char*)p, sizeof(DDSS));
-			}
-			
 		}
 	}
 


### PR DESCRIPTION
问题描述：
- DoRecv() 每次只读取一个 UDP 包，导致缓冲区堆积
- 长时间运行后读取到的是几秒前的旧数据（延迟可达数秒）
- 影响实时控制的准确性，1kHz 通信频率下状态数据严重滞后

修复内容：
- DoRecv() 函数改为循环读取所有堆积的 UDP 包
- 只使用最后一次读取的最新数据，主动丢弃旧数据
- 添加安全限制（最多读取 100 个包，防止无限循环）
- 跨平台支持（Linux EAGAIN/Windows WSAEWOULDBLOCK）
- 使用 static 临时变量避免频繁栈分配（1kHz 调用频率）
- 注释掉两行调试日志（清除 485 缓存提示）

业务逻辑：
- DCSS 机器人状态数据：丢弃旧数据，只保留最新状态（状态数据具有时效性）
- DDSS 通信数据：每个包都处理，不丢弃（可能包含指令或配置）
- 无新数据时保持上一次的最新值，确保 OnGetBuf() 始终返回有效数据
- 数据采集功能（m_GatherTag）会在堆积时丢失中间采样点（合理权衡）

影响文件：
- contrlSDK/Robot.cpp（line 493-1589）